### PR TITLE
Simplify user lookup in auth handlers

### DIFF
--- a/backend/src/controllers/authController.ts
+++ b/backend/src/controllers/authController.ts
@@ -117,22 +117,9 @@ export const login = async (req: Request, res: Response) => {
   try {
     const { username, password } = req.body;
 
-    // Try to find user in all collections
-    let user: any = await User.findOne({
+    const user: any = await User.findOne({
       $or: [{ username }, { email: username }]
     }).select('+password');
-
-    if (!user) {
-      user = await Student.findOne({
-        $or: [{ username }, { email: username }]
-      }).select('+password');
-    }
-
-    if (!user) {
-      user = await Teacher.findOne({
-        $or: [{ username }, { email: username }]
-      }).select('+password');
-    }
 
     if (!user || !(await user.comparePassword(password))) {
       return res.status(401).json({

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -1,8 +1,6 @@
 import { Request, Response, NextFunction } from 'express';
 import jwt from 'jsonwebtoken';
 import { User } from '../models/User';
-import { Student } from '../models/Student';
-import { Teacher } from '../models/Teacher';
 
 export interface AuthRequest extends Request {
   user?: any;
@@ -23,13 +21,7 @@ export const authenticateToken = async (req: AuthRequest, res: Response, next: N
     const jwtSecret = process.env.JWT_SECRET || 'your-secret-key';
     const decoded = jwt.verify(token, jwtSecret) as any;
     
-    let user: any = await User.findById(decoded.userId).select('-password');
-    if (!user) {
-      user = await Student.findById(decoded.userId).select('-password');
-    }
-    if (!user) {
-      user = await Teacher.findById(decoded.userId).select('-password');
-    }
+    const user: any = await User.findById(decoded.userId).select('-password');
     if (!user) {
       return res.status(401).json({
         success: false,


### PR DESCRIPTION
## Summary
- rely on the unified `User` model for login
- use `User.findById` when authenticating tokens
- drop unused `Student` and `Teacher` imports

## Testing
- `npm test` *(fails: `jest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_688ba2390388832c91709154cdb4573d