### PR TITLE
Add drag-and-drop lessons calendar

### DIFF
--- a/backend/src/routes/lessons.ts
+++ b/backend/src/routes/lessons.ts
@@ -7,7 +7,9 @@ import {
   requestCancel,
   approveReschedule,
   approveCancel,
-  createLesson
+  createLesson,
+  updateLesson,
+  deleteLesson
 } from '../controllers/lessonController';
 import { authenticateToken, requireRole } from '../middleware/auth';
 
@@ -29,5 +31,7 @@ router.post('/:id/request-cancel', requestCancel);
 router.post('/:id/approve-reschedule', requireRole(['teacher', 'admin']), approveReschedule);
 router.post('/:id/approve-cancel', requireRole(['teacher', 'admin']), approveCancel);
 router.post('/', requireRole(['teacher', 'admin']), createLesson);
+router.put('/:id', requireRole(['teacher', 'admin']), updateLesson);
+router.delete('/:id', requireRole(['teacher', 'admin']), deleteLesson);
 
 export default router;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,6 +23,8 @@
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.6.3",
     "react-scripts": "5.0.1",
+    "react-big-calendar": "^1.11.0",
+    "@types/react-big-calendar": "^1.5.0",
     "typescript": "^4.9.5",
     "web-vitals": "^2.1.4"
   },

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import Login from './components/auth/Login';
 import Register from './components/auth/Register';
 import Dashboard from './pages/Dashboard';
 import LessonsPage from './pages/Lessons';
+import CalendarPage from './pages/Calendar';
 import InstrumentsPage from './pages/Instruments';
 import InvoicesPage from './pages/Invoices';
 import StudentsPage from './pages/Students';
@@ -48,6 +49,14 @@ function App() {
               <ProtectedRoute>
                 <Layout>
                   <LessonsPage />
+                </Layout>
+              </ProtectedRoute>
+            } />
+
+            <Route path="/calendar" element={
+              <ProtectedRoute>
+                <Layout>
+                  <CalendarPage />
                 </Layout>
               </ProtectedRoute>
             } />

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -24,6 +24,7 @@ import {
   MusicNote as MusicNoteIcon,
   Receipt as ReceiptIcon,
   LibraryMusic as LibraryMusicIcon,
+  CalendarMonth as CalendarMonthIcon,
   People as PeopleIcon,
   AccountCircle,
   Logout,
@@ -76,6 +77,7 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
 
     const studentItems = [
       { text: 'My Lessons', icon: <SchoolIcon />, path: '/lessons' },
+      { text: 'Calendar', icon: <CalendarMonthIcon />, path: '/calendar' },
       { text: 'Invoices', icon: <ReceiptIcon />, path: '/invoices' },
       { text: 'Instruments', icon: <MusicNoteIcon />, path: '/instruments' },
     ];
@@ -83,6 +85,7 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
     const teacherItems = [
       { text: 'Students', icon: <PeopleIcon />, path: '/students' },
       { text: 'Lessons', icon: <SchoolIcon />, path: '/lessons' },
+      { text: 'Calendar', icon: <CalendarMonthIcon />, path: '/calendar' },
       { text: 'Invoices', icon: <ReceiptIcon />, path: '/invoices' },
       { text: 'Instruments', icon: <LibraryMusicIcon />, path: '/instruments' },
     ];

--- a/frontend/src/pages/Calendar.tsx
+++ b/frontend/src/pages/Calendar.tsx
@@ -1,0 +1,181 @@
+import React, { useEffect, useState } from 'react';
+import { Box, Button, Dialog, DialogActions, DialogContent, DialogTitle, Grid, TextField } from '@mui/material';
+import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
+import {
+  Calendar,
+  dateFnsLocalizer,
+  Event,
+} from 'react-big-calendar';
+import withDragAndDrop from 'react-big-calendar/lib/addons/dragAndDrop';
+import 'react-big-calendar/lib/css/react-big-calendar.css';
+import 'react-big-calendar/lib/addons/dragAndDrop/styles.css';
+import { format, parse, startOfWeek, getDay } from 'date-fns';
+import { enUS } from 'date-fns/locale';
+import { lessonsAPI, teachersAPI } from '../services/api';
+import { Lesson, Student } from '../types';
+import { useAuth } from '../contexts/AuthContext';
+
+const locales = {
+  'en-US': enUS,
+};
+
+const localizer = dateFnsLocalizer({
+  format,
+  parse,
+  startOfWeek: () => startOfWeek(new Date(), { weekStartsOn: 1 }),
+  getDay,
+  locales,
+});
+
+const DnDCalendar = withDragAndDrop(Calendar);
+
+interface LessonEvent extends Event {
+  resource: Lesson;
+}
+
+const CalendarPage: React.FC = () => {
+  const { user } = useAuth();
+  const [lessons, setLessons] = useState<Lesson[]>([]);
+  const [events, setEvents] = useState<LessonEvent[]>([]);
+  const [createDialog, setCreateDialog] = useState(false);
+  const [newLesson, setNewLesson] = useState({
+    title: '',
+    scheduledDate: new Date(),
+    duration: 60,
+    students: [] as string[],
+  });
+  const [availableStudents, setAvailableStudents] = useState<Student[]>([]);
+  const [selectedSlot, setSelectedSlot] = useState<any>(null);
+
+  const loadLessons = async () => {
+    const data = await lessonsAPI.getLessons();
+    setLessons(data);
+  };
+
+  useEffect(() => {
+    loadLessons();
+  }, []);
+
+  useEffect(() => {
+    if (user?.role === 'teacher') {
+      teachersAPI.getTeacherStudents(user._id).then(setAvailableStudents).catch(() => {});
+    }
+  }, [user]);
+
+  useEffect(() => {
+    const evts = lessons.map(l => ({
+      id: l._id,
+      title: l.title,
+      start: new Date(l.scheduledDate),
+      end: new Date(new Date(l.scheduledDate).getTime() + l.duration * 60000),
+      resource: l,
+    }));
+    setEvents(evts);
+  }, [lessons]);
+
+  const handleEventDrop = async ({ event, start, end }: any) => {
+    try {
+      await lessonsAPI.updateLesson(event.resource._id, {
+        scheduledDate: start.toISOString(),
+        duration: (end.getTime() - start.getTime()) / 60000,
+      });
+      loadLessons();
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  const handleSelectSlot = (slot: any) => {
+    if (user?.role !== 'teacher') return;
+    setSelectedSlot(slot);
+    setNewLesson({
+      ...newLesson,
+      scheduledDate: slot.start,
+      duration: (slot.end.getTime() - slot.start.getTime()) / 60000,
+    });
+    setCreateDialog(true);
+  };
+
+  const handleCreateLesson = async () => {
+    try {
+      await lessonsAPI.createLesson({
+        ...newLesson,
+        scheduledDate: newLesson.scheduledDate.toISOString(),
+      });
+      setCreateDialog(false);
+      setNewLesson({ title: '', scheduledDate: new Date(), duration: 60, students: [] });
+      loadLessons();
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const handleSelectEvent = async (event: LessonEvent) => {
+    if (user?.role !== 'teacher') return;
+    if (window.confirm('Delete this lesson?')) {
+      await lessonsAPI.deleteLesson(event.resource._id);
+      loadLessons();
+    }
+  };
+
+  return (
+    <LocalizationProvider dateAdapter={AdapterDateFns}>
+      <Box>
+        <DnDCalendar
+          localizer={localizer}
+          events={events}
+          selectable={user?.role === 'teacher'}
+          onEventDrop={handleEventDrop}
+          onEventResize={handleEventDrop}
+          resizable
+          onSelectSlot={handleSelectSlot}
+          onSelectEvent={handleSelectEvent}
+          style={{ height: 700 }}
+        />
+
+        <Dialog open={createDialog} onClose={() => setCreateDialog(false)} maxWidth="sm" fullWidth>
+          <DialogTitle>Create Lesson</DialogTitle>
+          <DialogContent>
+            <Grid container spacing={2} sx={{ mt: 1 }}>
+              <Grid item xs={12}>
+                <TextField
+                  fullWidth
+                  label="Title"
+                  value={newLesson.title}
+                  onChange={e => setNewLesson({ ...newLesson, title: e.target.value })}
+                />
+              </Grid>
+              <Grid item xs={12}>
+                <DateTimePicker
+                  label="Date & Time"
+                  value={newLesson.scheduledDate}
+                  onChange={date => setNewLesson({ ...newLesson, scheduledDate: date || new Date() })}
+                  slotProps={{ textField: { fullWidth: true } }}
+                />
+              </Grid>
+              <Grid item xs={12}>
+                <TextField
+                  fullWidth
+                  type="number"
+                  label="Duration (minutes)"
+                  value={newLesson.duration}
+                  onChange={e => setNewLesson({ ...newLesson, duration: parseInt(e.target.value) || 60 })}
+                />
+              </Grid>
+            </Grid>
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={() => setCreateDialog(false)}>Cancel</Button>
+            <Button variant="contained" onClick={handleCreateLesson} disabled={!newLesson.title}>
+              Create
+            </Button>
+          </DialogActions>
+        </Dialog>
+      </Box>
+    </LocalizationProvider>
+  );
+};
+
+export default CalendarPage;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -111,6 +111,15 @@ export const lessonsAPI = {
     const response: AxiosResponse<ApiResponse<Lesson>> = await api.post('/lessons', lessonData);
     return response.data.data!;
   },
+
+  updateLesson: async (id: string, lessonData: any): Promise<Lesson> => {
+    const response: AxiosResponse<ApiResponse<Lesson>> = await api.put(`/lessons/${id}`, lessonData);
+    return response.data.data!;
+  },
+
+  deleteLesson: async (id: string): Promise<void> => {
+    await api.delete(`/lessons/${id}`);
+  },
 };
 
 // Instruments API


### PR DESCRIPTION
## Summary
- implement lesson update & delete endpoints
- expose lesson update/delete API calls
- add calendar page with drag & drop scheduling
- add calendar navigation and route
- add react-big-calendar dependency

## Testing
- `npm test` *(fails: react-scripts not found)*
- `cd backend && npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688bb98aeb68832ca1f58a3063b85d54