### PR TITLE
Fix quick action for scheduling lessons

### DIFF
--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -24,6 +24,7 @@ import {
 import { useAuth } from '../contexts/AuthContext';
 import { lessonsAPI, instrumentsAPI } from '../services/api';
 import { Lesson, Instrument } from '../types';
+import { Link } from 'react-router-dom';
 import { format, isToday, isTomorrow } from 'date-fns';
 
 const Dashboard: React.FC = () => {
@@ -264,7 +265,11 @@ const Dashboard: React.FC = () => {
                   Quick Actions
                 </Typography>
                 <Box display="flex" flexDirection="column" gap={2}>
-                  <Button variant="contained" href="/lessons/new">
+                  <Button
+                    variant="contained"
+                    component={Link}
+                    to="/lessons?new=1"
+                  >
                     Schedule New Lesson
                   </Button>
                   <Button variant="outlined" href="/students">

--- a/frontend/src/pages/Lessons.tsx
+++ b/frontend/src/pages/Lessons.tsx
@@ -39,11 +39,13 @@ import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import { format } from 'date-fns';
 import { useAuth } from '../contexts/AuthContext';
+import { useLocation } from 'react-router-dom';
 import { lessonsAPI, teachersAPI } from '../services/api';
 import { Lesson, Student } from '../types';
 
 const Lessons: React.FC = () => {
   const { user } = useAuth();
+  const location = useLocation();
   const [lessons, setLessons] = useState<Lesson[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -72,6 +74,13 @@ const Lessons: React.FC = () => {
   useEffect(() => {
     loadLessons();
   }, []);
+
+  useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    if (params.get('new') === '1') {
+      setCreateDialogOpen(true);
+    }
+  }, [location.search]);
 
   useEffect(() => {
     const loadStudents = async () => {


### PR DESCRIPTION
## Summary
- Update dashboard quick action to use React Router Link and query param
- Open lesson creation dialog automatically when visiting `/lessons?new=1`

## Testing
- `cd frontend && CI=1 npm test -- --watchAll=false` (fails: Cannot find module 'react-router-dom')

------
https://chatgpt.com/codex/tasks/task_e_6892762cd838832c88a5062840a316ee