### PR TITLE
feat: add weekly recurring lessons

### DIFF
--- a/backend/src/controllers/lessonController.ts
+++ b/backend/src/controllers/lessonController.ts
@@ -335,7 +335,7 @@ export const createLesson = async (req: AuthRequest, res: Response) => {
     const teacherId = req.user._id;
     const lessons = [] as any[];
     let currentDate = new Date(scheduledDate);
-    const endDate = recurringUntil ? new Date(recurringUntil) : null;
+    const endDate = recurringUntil ? endOfDay(new Date(recurringUntil)) : null;
 
     while (!endDate || currentDate <= endDate) {
       const lesson = new Lesson({

--- a/backend/src/controllers/lessonController.ts
+++ b/backend/src/controllers/lessonController.ts
@@ -2,7 +2,7 @@ import { Response } from 'express';
 import { Lesson } from '../models/Lesson';
 import { User } from '../models/User';
 import { AuthRequest } from '../middleware/auth';
-import { startOfDay, endOfDay, parseISO } from 'date-fns';
+import { startOfDay, endOfDay, parseISO, addWeeks } from 'date-fns';
 
 export const getLessons = async (req: AuthRequest, res: Response) => {
   try {
@@ -328,34 +328,45 @@ export const createLesson = async (req: AuthRequest, res: Response) => {
       scheduledDate,
       duration,
       location,
-      notes
+      notes,
+      recurringUntil
     } = req.body;
 
     const teacherId = req.user._id;
+    const lessons = [] as any[];
+    let currentDate = new Date(scheduledDate);
+    const endDate = recurringUntil ? new Date(recurringUntil) : null;
 
-    const lesson = new Lesson({
-      type,
-      title,
-      description,
-      teacher: teacherId,
-      students,
-      scheduledDate: new Date(scheduledDate),
-      duration,
-      location,
-      notes
-    });
+    while (!endDate || currentDate <= endDate) {
+      const lesson = new Lesson({
+        type,
+        title,
+        description,
+        teacher: teacherId,
+        students,
+        scheduledDate: currentDate,
+        duration,
+        location,
+        notes
+      });
 
-    await lesson.save();
+      await lesson.save();
 
-    const populatedLesson = await lesson.populate([
-      { path: 'teacher', select: 'firstName lastName email' },
-      { path: 'students', select: 'firstName lastName email' }
-    ]);
+      const populated = await lesson.populate([
+        { path: 'teacher', select: 'firstName lastName email' },
+        { path: 'students', select: 'firstName lastName email' }
+      ]);
+
+      lessons.push(populated);
+
+      if (!endDate) break;
+      currentDate = addWeeks(currentDate, 1);
+    }
 
     res.status(201).json({
       success: true,
-      data: populatedLesson,
-      message: 'Lesson created successfully'
+      data: lessons,
+      message: lessons.length > 1 ? 'Lessons created successfully' : 'Lesson created successfully'
     });
   } catch (error) {
     console.error('Create lesson error:', error);

--- a/frontend/src/pages/Calendar.tsx
+++ b/frontend/src/pages/Calendar.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Box, Button, ButtonGroup, Typography, Dialog, DialogActions, DialogContent, DialogTitle, Grid, TextField, FormControl, InputLabel, Select, MenuItem } from '@mui/material';
 import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
+import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import {
@@ -72,6 +73,7 @@ const CalendarPage: React.FC = () => {
     scheduledDate: new Date(),
     duration: 60,
     students: [] as string[],
+    recurringUntil: null as Date | null,
   });
   const [availableStudents, setAvailableStudents] = useState<Student[]>([]);
   const [selectedSlot, setSelectedSlot] = useState<any>(null);
@@ -164,9 +166,10 @@ const CalendarPage: React.FC = () => {
       await lessonsAPI.createLesson({
         ...newLesson,
         scheduledDate: newLesson.scheduledDate.toISOString(),
+        recurringUntil: newLesson.recurringUntil?.toISOString(),
       });
       setCreateDialog(false);
-      setNewLesson({ title: '', scheduledDate: new Date(), duration: 60, students: [] });
+      setNewLesson({ title: '', scheduledDate: new Date(), duration: 60, students: [], recurringUntil: null });
       loadLessons();
     } catch (err) {
       console.error(err);
@@ -248,13 +251,21 @@ const CalendarPage: React.FC = () => {
                 />
               </Grid>
               <Grid size={{ xs: 12}}>
-                <DateTimePicker
-                  label="Date & Time"
-                  value={newLesson.scheduledDate}
-                  onChange={date => setNewLesson({ ...newLesson, scheduledDate: date || new Date() })}
-                  slotProps={{ textField: { fullWidth: true } }}
-                />
-              </Grid>
+              <DateTimePicker
+                label="Date & Time"
+                value={newLesson.scheduledDate}
+                onChange={date => setNewLesson({ ...newLesson, scheduledDate: date || new Date() })}
+                slotProps={{ textField: { fullWidth: true } }}
+              />
+            </Grid>
+            <Grid size={{ xs: 12}}>
+              <DatePicker
+                label="Repeat Weekly Until"
+                value={newLesson.recurringUntil}
+                onChange={date => setNewLesson({ ...newLesson, recurringUntil: date })}
+                slotProps={{ textField: { fullWidth: true } }}
+              />
+            </Grid>
               {user?.role === 'teacher' && (
                 <Grid size={{ xs: 12}}>
                   <FormControl fullWidth>

--- a/frontend/src/pages/Calendar.tsx
+++ b/frontend/src/pages/Calendar.tsx
@@ -69,6 +69,7 @@ const CalendarPage: React.FC = () => {
     students: [] as string[],
   });
   const [newLesson, setNewLesson] = useState({
+    type: 'private' as 'private' | 'masterclass' | 'group',
     title: '',
     scheduledDate: new Date(),
     duration: 60,
@@ -169,7 +170,14 @@ const CalendarPage: React.FC = () => {
         recurringUntil: newLesson.recurringUntil?.toISOString(),
       });
       setCreateDialog(false);
-      setNewLesson({ title: '', scheduledDate: new Date(), duration: 60, students: [], recurringUntil: null });
+      setNewLesson({
+        type: 'private',
+        title: '',
+        scheduledDate: new Date(),
+        duration: 60,
+        students: [],
+        recurringUntil: null,
+      });
       loadLessons();
     } catch (err) {
       console.error(err);
@@ -249,6 +257,20 @@ const CalendarPage: React.FC = () => {
                   value={newLesson.title}
                   onChange={e => setNewLesson({ ...newLesson, title: e.target.value })}
                 />
+              </Grid>
+              <Grid size={{ xs: 12}}>
+                <FormControl fullWidth>
+                  <InputLabel>Type</InputLabel>
+                  <Select
+                    value={newLesson.type}
+                    label="Type"
+                    onChange={e => setNewLesson({ ...newLesson, type: e.target.value as any })}
+                  >
+                    <MenuItem value="private">Private</MenuItem>
+                    <MenuItem value="group">Group</MenuItem>
+                    <MenuItem value="masterclass">Masterclass</MenuItem>
+                  </Select>
+                </FormControl>
               </Grid>
               <Grid size={{ xs: 12}}>
               <DateTimePicker

--- a/frontend/src/pages/Calendar.tsx
+++ b/frontend/src/pages/Calendar.tsx
@@ -68,14 +68,18 @@ const CalendarPage: React.FC = () => {
     duration: 60,
     students: [] as string[],
   });
-  const [newLesson, setNewLesson] = useState({
+  const initialNewLesson = {
     type: 'private' as 'private' | 'masterclass' | 'group',
     title: '',
+    description: '',
     scheduledDate: new Date(),
     duration: 60,
+    location: '',
+    notes: '',
     students: [] as string[],
     recurringUntil: null as Date | null,
-  });
+  };
+  const [newLesson, setNewLesson] = useState(initialNewLesson);
   const [availableStudents, setAvailableStudents] = useState<Student[]>([]);
   const [selectedSlot, setSelectedSlot] = useState<any>(null);
   const [range, setRange] = useState<{ start: Date; end: Date } | null>(null);
@@ -154,11 +158,7 @@ const CalendarPage: React.FC = () => {
   const handleSelectSlot = (slot: any) => {
     if (user?.role !== 'teacher') return;
     setSelectedSlot(slot);
-    setNewLesson({
-      ...newLesson,
-      scheduledDate: slot.start,
-      duration: (slot.end.getTime() - slot.start.getTime()) / 60000,
-    });
+    setNewLesson({ ...initialNewLesson, scheduledDate: slot.start });
     setCreateDialog(true);
   };
 
@@ -170,15 +170,8 @@ const CalendarPage: React.FC = () => {
         recurringUntil: newLesson.recurringUntil?.toISOString(),
       });
       setCreateDialog(false);
-      setNewLesson({
-        type: 'private',
-        title: '',
-        scheduledDate: new Date(),
-        duration: 60,
-        students: [],
-        recurringUntil: null,
-      });
-      loadLessons();
+      setNewLesson({ ...initialNewLesson });
+      await loadLessons(range?.start, range?.end);
     } catch (err) {
       console.error(err);
     }
@@ -318,6 +311,34 @@ const CalendarPage: React.FC = () => {
                   label="Duration (minutes)"
                   value={newLesson.duration}
                   onChange={e => setNewLesson({ ...newLesson, duration: parseInt(e.target.value) || 60 })}
+                />
+              </Grid>
+              <Grid size={{ xs: 12}}>
+                <TextField
+                  fullWidth
+                  label="Location"
+                  value={newLesson.location}
+                  onChange={e => setNewLesson({ ...newLesson, location: e.target.value })}
+                />
+              </Grid>
+              <Grid size={{ xs: 12}}>
+                <TextField
+                  fullWidth
+                  multiline
+                  rows={3}
+                  label="Description"
+                  value={newLesson.description}
+                  onChange={e => setNewLesson({ ...newLesson, description: e.target.value })}
+                />
+              </Grid>
+              <Grid size={{ xs: 12}}>
+                <TextField
+                  fullWidth
+                  multiline
+                  rows={2}
+                  label="Notes"
+                  value={newLesson.notes}
+                  onChange={e => setNewLesson({ ...newLesson, notes: e.target.value })}
                 />
               </Grid>
             </Grid>

--- a/frontend/src/pages/Lessons.tsx
+++ b/frontend/src/pages/Lessons.tsx
@@ -35,6 +35,7 @@ import {
   LocationOn as LocationOnIcon,
 } from '@mui/icons-material';
 import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
+import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import { format } from 'date-fns';
@@ -68,7 +69,8 @@ const Lessons: React.FC = () => {
     scheduledDate: new Date(),
     duration: 60,
     location: '',
-    notes: ''
+    notes: '',
+    recurringUntil: null as Date | null
   });
 
   useEffect(() => {
@@ -115,6 +117,7 @@ const Lessons: React.FC = () => {
       await lessonsAPI.createLesson({
         ...newLesson,
         scheduledDate: newLesson.scheduledDate.toISOString(),
+        recurringUntil: newLesson.recurringUntil?.toISOString(),
       });
       setCreateDialogOpen(false);
       setNewLesson({
@@ -125,7 +128,8 @@ const Lessons: React.FC = () => {
         scheduledDate: new Date(),
         duration: 60,
         location: '',
-        notes: ''
+        notes: '',
+        recurringUntil: null
       });
       loadLessons();
     } catch (err: any) {
@@ -438,13 +442,21 @@ const Lessons: React.FC = () => {
                 </FormControl>
               </Grid>
               <Grid size={{ xs: 12}}>
-                <DateTimePicker
-                  label="Scheduled Date & Time"
-                  value={newLesson.scheduledDate}
-                  onChange={(date) => setNewLesson({ ...newLesson, scheduledDate: date || new Date() })}
-                  slotProps={{ textField: { fullWidth: true } }}
-                />
-              </Grid>
+              <DateTimePicker
+                label="Scheduled Date & Time"
+                value={newLesson.scheduledDate}
+                onChange={(date) => setNewLesson({ ...newLesson, scheduledDate: date || new Date() })}
+                slotProps={{ textField: { fullWidth: true } }}
+              />
+            </Grid>
+            <Grid size={{ xs: 12}}>
+              <DatePicker
+                label="Repeat Weekly Until"
+                value={newLesson.recurringUntil}
+                onChange={(date) => setNewLesson({ ...newLesson, recurringUntil: date })}
+                slotProps={{ textField: { fullWidth: true } }}
+              />
+            </Grid>
               {user?.role === 'teacher' && (
                 <Grid size={{ xs: 12}}>
                   <FormControl fullWidth>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -107,8 +107,8 @@ export const lessonsAPI = {
     return response.data.data!;
   },
 
-  createLesson: async (lessonData: any): Promise<Lesson> => {
-    const response: AxiosResponse<ApiResponse<Lesson>> = await api.post('/lessons', lessonData);
+  createLesson: async (lessonData: any): Promise<Lesson[]> => {
+    const response: AxiosResponse<ApiResponse<Lesson[]>> = await api.post('/lessons', lessonData);
     return response.data.data!;
   },
 


### PR DESCRIPTION
## Summary
- support creating weekly recurring lessons in backend
- allow specifying repeat-until date when creating lessons in calendar and lessons pages
- return all created lessons from lessons API

## Testing
- `cd backend && npm test -- --passWithNoTests`
- `cd frontend && npm test -- --passWithNoTests` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_68927851a5ec832c8d636dd371f7277a