### PR TITLE
Add teacher selection to student registration and fix student deletion

### DIFF
--- a/backend/src/controllers/authController.ts
+++ b/backend/src/controllers/authController.ts
@@ -28,6 +28,7 @@ export const register = async (req: Request, res: Response) => {
       motherPhone,
       fatherName,
       fatherPhone,
+      teacher: teacherId,
       // Teacher specific fields
       specializations,
       availability
@@ -62,7 +63,8 @@ export const register = async (req: Request, res: Response) => {
         motherName,
         motherPhone,
         fatherName,
-        fatherPhone
+        fatherPhone,
+        teacher: teacherId
       });
     } else if (role === 'teacher') {
       user = new Teacher({
@@ -87,6 +89,10 @@ export const register = async (req: Request, res: Response) => {
     }
 
     await user.save();
+
+    if (role === 'student' && teacherId) {
+      await Teacher.findByIdAndUpdate(teacherId, { $addToSet: { students: user._id } });
+    }
 
     const token = generateToken((user._id as any).toString());
 

--- a/backend/src/controllers/studentController.ts
+++ b/backend/src/controllers/studentController.ts
@@ -228,12 +228,18 @@ export const updateStudent = async (req: AuthRequest, res: Response) => {
 export const deleteStudent = async (req: AuthRequest, res: Response) => {
   try {
     const student = await Student.findById(req.params.id);
-    
+
     if (!student) {
       return res.status(404).json({ success: false, message: 'Student not found' });
     }
 
-    await Student.findByIdAndDelete(req.params.id);
+    if (student.teacher) {
+      await Teacher.findByIdAndUpdate(student.teacher, {
+        $pull: { students: student._id }
+      });
+    }
+
+    await student.deleteOne();
     res.json({ success: true, message: 'Student deleted successfully' });
   } catch (error) {
     console.error('Error deleting student:', error);

--- a/backend/src/controllers/teacherController.ts
+++ b/backend/src/controllers/teacherController.ts
@@ -1,4 +1,4 @@
-import { Response } from 'express';
+import { Response, Request } from 'express';
 import { Teacher } from '../models/Teacher';
 import { Student } from '../models/Student';
 import { AuthRequest } from '../middleware/auth';
@@ -50,6 +50,16 @@ export const getTeacherStudents = async (req: AuthRequest, res: Response) => {
     });
   } catch (error) {
     console.error('Error fetching teacher students:', error);
+    res.status(500).json({ message: 'Server error' });
+  }
+};
+
+export const getPublicTeachers = async (req: Request, res: Response) => {
+  try {
+    const teachers = await Teacher.find().select('firstName lastName email');
+    res.json({ success: true, data: teachers });
+  } catch (error) {
+    console.error('Error fetching teachers:', error);
     res.status(500).json({ message: 'Server error' });
   }
 };

--- a/backend/src/routes/teachers.ts
+++ b/backend/src/routes/teachers.ts
@@ -3,10 +3,13 @@ import { authenticate, requireRole } from '../middleware/auth';
 import {
   getTeachers,
   getTeacherById,
-  getTeacherStudents
+  getTeacherStudents,
+  getPublicTeachers,
 } from '../controllers/teacherController';
 
 const router = express.Router();
+
+router.get('/public', getPublicTeachers);
 
 router.use(authenticate);
 

--- a/frontend/src/components/auth/Register.tsx
+++ b/frontend/src/components/auth/Register.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   Box,
   Paper,
@@ -20,7 +20,8 @@ import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import { useAuth } from '../../contexts/AuthContext';
 import { useNavigate, Link as RouterLink } from 'react-router-dom';
-import { RegisterData } from '../../types';
+import { RegisterData, Teacher } from '../../types';
+import { teachersAPI } from '../../services/api';
 
 const Register: React.FC = () => {
   const [formData, setFormData] = useState<RegisterData>({
@@ -39,15 +40,29 @@ const Register: React.FC = () => {
     motherPhone: '',
     fatherName: '',
     fatherPhone: '',
+    teacher: '',
     // Teacher fields
     specializations: [],
   });
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
   const [birthDate, setBirthDate] = useState<Date | null>(null);
+  const [teachers, setTeachers] = useState<Teacher[]>([]);
 
   const { register } = useAuth();
   const navigate = useNavigate();
+
+  useEffect(() => {
+    const loadTeachers = async () => {
+      try {
+        const data = await teachersAPI.getTeachers();
+        setTeachers(data);
+      } catch (err) {
+        // ignore
+      }
+    };
+    loadTeachers();
+  }, []);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | { name?: string; value: unknown }>) => {
     const name = e.target.name as keyof RegisterData;
@@ -59,15 +74,14 @@ const Register: React.FC = () => {
     });
   };
 
-  const handleSelectChange = (e: SelectChangeEvent<"student" | "teacher">) => {
+  const handleSelectChange = (e: SelectChangeEvent) => {
     const name = e.target.name as keyof RegisterData;
     const value = e.target.value;
-    
     setFormData({
       ...formData,
       [name]: value,
     });
-  };  
+  };
 
   const handleDateChange = (date: Date | null) => {
     setBirthDate(date);
@@ -186,6 +200,23 @@ const Register: React.FC = () => {
                 {/* Student-specific fields */}
                 {formData.role === 'student' && (
                   <>
+                    <Grid size={{ xs: 12, sm: 6 }}>
+                      <FormControl fullWidth required>
+                        <InputLabel>Teacher</InputLabel>
+                        <Select
+                          name="teacher"
+                          value={formData.teacher}
+                          label="Teacher"
+                          onChange={handleSelectChange}
+                        >
+                          {teachers.map((t) => (
+                            <MenuItem key={t._id} value={t._id}>
+                              {t.firstName} {t.lastName}
+                            </MenuItem>
+                          ))}
+                        </Select>
+                      </FormControl>
+                    </Grid>
                     <Grid size={{ xs: 12, sm: 6 }}>
                       <DatePicker
                         label="Birth Date"

--- a/frontend/src/pages/Students.tsx
+++ b/frontend/src/pages/Students.tsx
@@ -47,8 +47,10 @@ import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import { format } from 'date-fns';
 import { studentsAPI } from '../services/api';
 import { Student } from '../types';
+import { useAuth } from '../contexts/AuthContext';
 
 const StudentsPage: React.FC = () => {
+  const { user } = useAuth();
   const [students, setStudents] = useState<Student[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -424,14 +426,16 @@ const StudentsPage: React.FC = () => {
                       <EditIcon />
                     </IconButton>
                   </Tooltip>
-                  <Tooltip title="Delete">
-                    <IconButton
-                      onClick={() => handleDelete(student._id)}
-                      color="error"
-                    >
-                      <DeleteIcon />
-                    </IconButton>
-                  </Tooltip>
+                    {user?.role === 'admin' && (
+                      <Tooltip title="Delete">
+                        <IconButton
+                          onClick={() => handleDelete(student._id)}
+                          color="error"
+                        >
+                          <DeleteIcon />
+                        </IconButton>
+                      </Tooltip>
+                    )}
                 </TableCell>
               </TableRow>
             ))}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -8,7 +8,8 @@ import {
   Lesson,
   Instrument,
   Invoice,
-  Student
+  Student,
+  Teacher
 } from '../types';
 
 const API_BASE_URL = process.env.REACT_APP_API_URL || 'http://localhost:5001/api';
@@ -213,6 +214,10 @@ export const studentsAPI = {
 
 // Teachers API
 export const teachersAPI = {
+  getTeachers: async (): Promise<Teacher[]> => {
+    const response: AxiosResponse<ApiResponse<Teacher[]>> = await api.get('/teachers/public');
+    return response.data.data!;
+  },
   getTeacherStudents: async (id: string): Promise<Student[]> => {
     const response: AxiosResponse<ApiResponse<Student[]>> = await api.get(`/teachers/${id}/students`);
     return response.data.data!;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -115,6 +115,7 @@ export interface RegisterData {
   motherPhone?: string;
   fatherName?: string;
   fatherPhone?: string;
+  teacher?: string;
   // Teacher specific
   specializations?: string[];
   availability?: TeacherAvailability[];


### PR DESCRIPTION
## Summary
- allow selecting a teacher during student registration
- expose public teacher list endpoint and wire dropdown to it
- clean up teacher references when deleting students and hide delete action for non-admins

## Testing
- `npm test` (backend) *(fails: No tests found)*
- `CI=true npm test` (frontend) *(fails: Cannot find module 'react-router-dom' from 'src/App.tsx')*

------
https://chatgpt.com/codex/tasks/task_e_689282794968832c81f49d55a82bc2e2