### PR TITLE
style calendar events by lesson status

### DIFF
--- a/frontend/src/pages/Calendar.css
+++ b/frontend/src/pages/Calendar.css
@@ -15,10 +15,10 @@
 .rbc-event.lesson-cancelled::after {
   content: '';
   position: absolute;
-  top: 0;
+  top: 50%;
   left: 0;
   width: 100%;
-  height: 100%;
-  background: linear-gradient(135deg, transparent calc(50% - 1px), #d32f2f calc(50% - 1px), #d32f2f calc(50% + 1px), transparent calc(50% + 1px));
+  border-top: 2px solid #d32f2f;
+  transform: translateY(-50%);
   pointer-events: none;
 }

--- a/frontend/src/pages/Calendar.css
+++ b/frontend/src/pages/Calendar.css
@@ -4,18 +4,21 @@
   color: #000;
 }
 
-.rbc-event.lesson-cancelling {
+.rbc-event.lesson-cancelled {
   background-color: white;
   border: 2px solid #d32f2f;
   color: #000;
   position: relative;
+  overflow: hidden;
 }
 
-.rbc-event.lesson-cancelling::after {
-  content: '✕';
-  color: #d32f2f;
-  font-weight: bold;
+.rbc-event.lesson-cancelled::after {
+  content: '';
   position: absolute;
-  top: 2px;
-  right: 4px;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(135deg, transparent calc(50% - 1px), #d32f2f calc(50% - 1px), #d32f2f calc(50% + 1px), transparent calc(50% + 1px));
+  pointer-events: none;
 }

--- a/frontend/src/pages/Calendar.css
+++ b/frontend/src/pages/Calendar.css
@@ -1,0 +1,21 @@
+.rbc-event.lesson-rescheduling {
+  background-color: white;
+  border: 2px solid #1976d2;
+  color: #000;
+}
+
+.rbc-event.lesson-cancelling {
+  background-color: white;
+  border: 2px solid #d32f2f;
+  color: #000;
+  position: relative;
+}
+
+.rbc-event.lesson-cancelling::after {
+  content: '✕';
+  color: #d32f2f;
+  font-weight: bold;
+  position: absolute;
+  top: 2px;
+  right: 4px;
+}

--- a/frontend/src/pages/Calendar.tsx
+++ b/frontend/src/pages/Calendar.tsx
@@ -233,8 +233,8 @@ const CalendarPage: React.FC = () => {
             if (event.resource.status === 'rescheduling') {
               return { className: 'lesson-rescheduling' };
             }
-            if (event.resource.status === 'cancelling') {
-              return { className: 'lesson-cancelling' };
+            if (event.resource.status === 'cancelled') {
+              return { className: 'lesson-cancelled' };
             }
             return {};
           }}

--- a/frontend/src/pages/Calendar.tsx
+++ b/frontend/src/pages/Calendar.tsx
@@ -12,6 +12,7 @@ import {
 import withDragAndDrop from 'react-big-calendar/lib/addons/dragAndDrop';
 import 'react-big-calendar/lib/css/react-big-calendar.css';
 import 'react-big-calendar/lib/addons/dragAndDrop/styles.css';
+import './Calendar.css';
 import { format, parse, startOfWeek, getDay, startOfMonth, endOfMonth } from 'date-fns';
 import { View } from 'react-big-calendar';
 import { enUS } from 'date-fns/locale';
@@ -228,6 +229,15 @@ const CalendarPage: React.FC = () => {
           date={currentDate}
           view={view}
           selectable={user?.role === 'teacher'}
+          eventPropGetter={(event) => {
+            if (event.resource.status === 'rescheduling') {
+              return { className: 'lesson-rescheduling' };
+            }
+            if (event.resource.status === 'cancelling') {
+              return { className: 'lesson-cancelling' };
+            }
+            return {};
+          }}
           onEventDrop={handleEventDrop}
           onEventResize={handleEventDrop}
           resizable

--- a/frontend/src/pages/Lessons.tsx
+++ b/frontend/src/pages/Lessons.tsx
@@ -203,9 +203,10 @@ const Lessons: React.FC = () => {
     }
   };
 
-  const openActionDialog = (lesson: Lesson, type: any) => {
+  const openActionDialog = (lesson: Lesson, type: any, data: any = {}) => {
     setSelectedLesson(lesson);
     setActionType(type);
+    setActionData(data);
     setActionDialogOpen(true);
   };
 
@@ -321,7 +322,7 @@ const Lessons: React.FC = () => {
                     size="small"
                     variant="contained"
                     color="success"
-                    onClick={() => openActionDialog(lesson, 'approve-reschedule')}
+                    onClick={() => openActionDialog(lesson, 'approve-reschedule', { approved: true })}
                   >
                     Approve Reschedule
                   </Button>
@@ -329,7 +330,7 @@ const Lessons: React.FC = () => {
                     size="small"
                     variant="outlined"
                     color="error"
-                    onClick={() => openActionDialog(lesson, 'approve-reschedule')}
+                    onClick={() => openActionDialog(lesson, 'approve-reschedule', { approved: false })}
                   >
                     Deny Reschedule
                   </Button>
@@ -341,7 +342,7 @@ const Lessons: React.FC = () => {
                     size="small"
                     variant="contained"
                     color="success"
-                    onClick={() => openActionDialog(lesson, 'approve-cancel')}
+                    onClick={() => openActionDialog(lesson, 'approve-cancel', { approved: true })}
                   >
                     Approve Cancel
                   </Button>
@@ -349,7 +350,7 @@ const Lessons: React.FC = () => {
                     size="small"
                     variant="outlined"
                     color="error"
-                    onClick={() => openActionDialog(lesson, 'approve-cancel')}
+                    onClick={() => openActionDialog(lesson, 'approve-cancel', { approved: false })}
                   >
                     Deny Cancel
                   </Button>
@@ -537,8 +538,8 @@ const Lessons: React.FC = () => {
             {actionType === 'confirm' && 'I am Here'}
             {actionType === 'reschedule' && 'Request Reschedule'}
             {actionType === 'cancel' && 'Request Cancellation'}
-            {actionType === 'approve-reschedule' && 'Approve Reschedule'}
-            {actionType === 'approve-cancel' && 'Approve Cancellation'}
+            {actionType === 'approve-reschedule' && (actionData.approved ? 'Approve Reschedule' : 'Deny Reschedule')}
+            {actionType === 'approve-cancel' && (actionData.approved ? 'Approve Cancellation' : 'Deny Cancellation')}
           </DialogTitle>
           <DialogContent>
             {(actionType === 'reschedule' || actionType === 'cancel') && (
@@ -563,19 +564,21 @@ const Lessons: React.FC = () => {
             {actionType === 'approve-reschedule' && (
               <Box sx={{ mt: 2 }}>
                 <Typography variant="body2" gutterBottom>
-                  Do you want to approve this reschedule request?
+                  {actionData.approved ? 'Do you want to approve this reschedule request?' : 'Do you want to deny this reschedule request?'}
                 </Typography>
-                <DateTimePicker
-                  label="New Date & Time (optional)"
-                  value={actionData.newDate || null}
-                  onChange={(date) => setActionData({ ...actionData, newDate: date })}
-                  slotProps={{ textField: { fullWidth: true, sx: { mt: 2 } } }}
-                />
+                {actionData.approved && (
+                  <DateTimePicker
+                    label="New Date & Time (optional)"
+                    value={actionData.newDate || null}
+                    onChange={(date) => setActionData({ ...actionData, newDate: date })}
+                    slotProps={{ textField: { fullWidth: true, sx: { mt: 2 } } }}
+                  />
+                )}
               </Box>
             )}
             {actionType === 'approve-cancel' && (
               <Typography variant="body2" sx={{ mt: 2 }}>
-                Do you want to approve this cancellation request?
+                {actionData.approved ? 'Do you want to approve this cancellation request?' : 'Do you want to deny this cancellation request?'}
               </Typography>
             )}
           </DialogContent>


### PR DESCRIPTION
## Summary
- style rescheduling lessons with a blue border and white background
- style cancelling lessons with a red border, white background, and an X marker
- apply status-based classes to calendar events

## Testing
- `cd frontend && npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom' from 'src/App.tsx')*

------
https://chatgpt.com/codex/tasks/task_e_6892bbd59214832c889352cad80c50e4