### PR TITLE
feat: add teacher pending actions quick stat

### DIFF
--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -17,6 +17,7 @@ import {
   MusicNote as MusicNoteIcon,
   Receipt as ReceiptIcon,
   EventAvailable as EventAvailableIcon,
+  PendingActions as PendingActionsIcon,
 } from '@mui/icons-material';
 //import { useAuth } from '../../contexts/AuthContext';
 //import { lessonsAPI, instrumentsAPI } from '../../services/api';
@@ -169,6 +170,26 @@ const Dashboard: React.FC = () => {
                     </Typography>
                     <Typography variant="h4">
                       {myInstruments.length}
+                    </Typography>
+                  </Box>
+                </Box>
+              </CardContent>
+            </Card>
+          </Grid>
+        )}
+
+        {user?.role === 'teacher' && (
+          <Grid size={{ xs: 12, sm: 6, md:3}}>
+            <Card>
+              <CardContent>
+                <Box display="flex" alignItems="center">
+                  <PendingActionsIcon color="info" sx={{ mr: 2, fontSize: 40 }} />
+                  <Box>
+                    <Typography color="textSecondary" gutterBottom>
+                      Pending Actions
+                    </Typography>
+                    <Typography variant="h4">
+                      {pendingLessons.length}
                     </Typography>
                   </Box>
                 </Box>


### PR DESCRIPTION
## Summary
- add Pending Actions quick-stat card for teachers between Upcoming Lessons and Pending Invoices
- import PendingActions icon

## Testing
- `cd frontend && npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom' from 'src/App.tsx')*


------
https://chatgpt.com/codex/tasks/task_e_689421d77fa0832c9f8285e04fcf44dd